### PR TITLE
Add mobile responsive design to footer

### DIFF
--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -5,16 +5,11 @@
     margin-left: 20px;
 }
 
-
-
-
 .rights {
     background-color: #F4E6D7;
     line-height: 65px;
     text-align: center;
 }
-
-
 
 .footerContent {
     display: flex;
@@ -57,4 +52,50 @@
 .miniLogo {
     height: auto;
     width: 90px;
+}
+
+/* Mobile view - Media queries */
+@media (max-width: 768px) {
+    .footerContent {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 30px;
+        background-color: #F4E6D7;
+        margin: 0;
+    }
+
+    .footerLinks {
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+        max-width: none;
+        width: 100%;
+    }
+
+    .footerLink {
+        padding: 10px 0;
+        font-size: 16px;
+    }
+
+    .socialMedia {
+        margin-top: 20px;
+        order: 2;
+    }
+
+    .socialIcons {
+        justify-content: center;
+        gap: 20px;
+        margin-top: 10px;
+    }
+
+    .socialIcon {
+        height: 35px;
+        width: 35px;
+    }
+
+    .logoContainer {
+        justify-content: center;
+        margin-left: 0;
+    }
 }


### PR DESCRIPTION
Add mobile responsive design to footer:
- Links now display in column layout on mobile
- Social media icons arranged in row at bottom
- Improved spacing and centering for mobile view
- Added media query for screens 768px and below